### PR TITLE
Update wsprdaemon.sh

### DIFF
--- a/wsprdaemon.sh
+++ b/wsprdaemon.sh
@@ -101,7 +101,7 @@ shopt -s -o nounset          ### bash stops with error if undeclared variable is
                                    ### 3) one can configure to only measure noise and log it, only publish graphs to graphs.wsprdaemon.org, only publish graphs to localhost running Apache, or publish to both
                                    ### 4) download and install only the SW packages required by the configuration (e.g. no apache2 if you aren't publishing locally)
                                    ### 5) publishing graphs to graphs.wsprdaemon.org  no longer requires one to set up ssh auto-login.
-                                   ### 6) added -Z, heck for and offer to kill zombies and add it to -z
+                                   ### 6) added -Z, check for and offer to kill zombies and add it to -z
 #declare -r VERSION=2.5             ### Release to public, same as 2.4j
 #declare -r VERSION=2.5a             ### Enhance checks for zombies.  Add support for installation of WSJT-x on x86 machines
 declare -r VERSION=2.5b             ### Extend wait time to 30 seconds during schedule changes, but still seeing WD listeners on wrong RX 0/1. 


### PR DESCRIPTION
- Extend wait time to 30 seconds during schedule changes, but still seeing WD listeners on wrong RX 0/1. 
- Prompt user before installing new SW.  Graphs now -165 to -115
- Use /tmp/wsprdaemon/... and move all WD temp files there,
- Verify that the best SNR from the MERGED_RX are 
- Added log output from two checks for GPS lock .  Fix in Kiwi V1.335 seems to fix the 'permanent loss of GPS lock'  problem 
- Added overload (OV) detection and reporting to watchdog.log at verbosity=1 and above
- Added logging of  WD listeners on RX0/1 channel when verbosity > 1