### PR TITLE
Limit individual curl upload transactions to no more than 200 spots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.wsprdaemon.sh.swp
+expected.jobs
+hashtable.d
+hhmm.sched
+kiwiclient
+noise_plot
+running.jobs
+signal_levels
+suntimes
+watchdog.log
+watchdog.pid
+wsprdaemon.conf
+save


### PR DESCRIPTION
This hopefully helps when WD assembles a large cache of spots while wsprnet.org is offline