### PR TITLE
github no longer allows git:// checkouts

### DIFF
--- a/wsprdaemon.sh
+++ b/wsprdaemon.sh
@@ -271,7 +271,7 @@ function check_for_kiwirecorder_cmd() {
             [[ ${apt_update_done} == "no" ]] && sudo apt-get --yes update && apt_update_done="yes"
             sudo apt-get --yes install git
         fi
-        git clone git://github.com/jks-prv/kiwiclient
+        git clone https://github.com/jks-prv/kiwiclient
         echo "Downloading the kiwirecorder SW from Github..." 
         if [[ ! -x ${KIWI_RECORD_COMMAND} ]]; then 
             echo "ERROR: can't find the kiwirecorder.py command needed to communicate with a KiwiSDR.  Download it from https://github.com/jks-prv/kiwiclient/tree/jks-v0.1"


### PR DESCRIPTION
When initially installing wsprdaemon, github no longer allows checkout of repositories with the git:// URL, so the kiwirecorder clone fails. As of March 15th, switch to https://

```
Installing kiwirecorder in /home/wsprdaemon/wsprdaemon-bklofas
Cloning into 'kiwiclient'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Downloading the kiwirecorder SW from Github...
ERROR: can't find the kiwirecorder.py command needed to communicate with a KiwiSDR.  Download it from https://github.com/jks-prv/kiwiclient/tree/jks-v0.1
       You may also need to install the Python library 'numpy' with:  sudo apt-get install python-numpy

```