### PR TITLE
Fix wav_file_regex so that 2.5 and 25 MHz files are distinct

### DIFF
--- a/decoding.sh
+++ b/decoding.sh
@@ -778,7 +778,7 @@ function get_wav_file_list() {
 
     ### The pcmrecord wav files are created with names which different from those created by kiwirecorder
     local band_freq_hz=$( get_wspr_band_freq_hz ${receiver_band} )
-    local wav_file_regex="*_${band_freq_hz}*.wav"
+    local wav_file_regex="*_${band_freq_hz}_*.wav"
 
     # Start:
     # Find all wav files for this band abd sort by reverse time (i.e newest in [0]


### PR DESCRIPTION
The wav_file_regex in decoding.sh:get_wav_file_list() was matching on both 2.5 and 25 MHz WWV wav files in the
/dev/shm/wsprdaemon/recording.d/KA9Q_0_WWV/WWV_2_5 directory, leading to all sorts of confusion. Before this fix I didn't see any archived 25 MHz files, and now I do.

I hope this fix doesn't break anything else!