### PR TITLE
Add args to sox to create floating point 10 Hz GRAPE wav files

### DIFF
--- a/grape-utils.sh
+++ b/grape-utils.sh
@@ -518,7 +518,7 @@ function grape_create_wav_file()
     wd_logger 1 "Creating one 24 hour, 10 hz wav file ${output_10sps_wav_file} from ${#compressed_wav_file_list[@]} .wv files..."
     local sox_log_file_name="${compressed_wav_file_dir}/sox.log"
     ulimit -n 2048    ### sox will open 1440+ files, so up the open file limit
-    nice -n 19 sox ${compressed_wav_file_list[@]} ${output_10sps_wav_file} rate 10 >& ${sox_log_file_name}
+    nice -n 19 sox ${compressed_wav_file_list[@]} --encoding float --bits 32 ${output_10sps_wav_file} rate 10 >& ${sox_log_file_name}
     rc=$? ; if (( rc )); then
         wd_logger 1 "ERROR: 'sox ...' => ${rc}:\n$(<${sox_log_file_name})"
          return ${GRAPE_ERROR_SOX_FAILED}


### PR DESCRIPTION
Modify sox command line in grape-utils.sh:grape_create_wav_file() to output a 32 bit floating point 10 Hz wav file for GRAPE. It appears sox by default was outputing signed 32 bit int wav files.

soxi output before:
Input File     : '24_hour_10sps_iq.wav'
Channels       : 2
Sample Rate    : 10
Precision      : 32-bit
Duration       : 24:00:00.00 = 864000 samples ~ 6.48e+06 CDDA sectors
File Size      : 6.91M
Bit Rate       : 640
Sample Encoding: 32-bit Signed Integer PCM

soxi output after:
Input File     : '24_hour_10sps_iq.wav'
Channels       : 2
Sample Rate    : 10
Precision      : 25-bit
Duration       : 24:00:00.00 = 864000 samples ~ 6.48e+06 CDDA sectors
File Size      : 6.88M
Bit Rate       : 637
Sample Encoding: 32-bit Floating Point PCM