### PR TITLE
    Update pcmrecord to work with ka9q-radio commit e449ab4

### DIFF
--- a/pcmrecord.c
+++ b/pcmrecord.c
@@ -340,7 +340,7 @@ int main(int argc,char *argv[]){
       break;
     case 'V':
       VERSION();
-      fputs("wsprdaemon mode (-W): v0.10\n",stdout);
+      fputs("wsprdaemon mode (-W): v0.11\n",stdout);
       exit(EX_OK);
     case 'W':
       wd_mode = true;


### PR DESCRIPTION
Back to F32LE! Exit with error if stream is big endian 32 bit floats, litle endian 16 bit ints, or 16 bit floating point. For now, only big endian 16 bit ints and little endian 32 bit floats are accepted in -W mode.

Tested against ka9q-radio commit:

commit e449ab45a4628dda5b3252e4e4d64d64ff3dc17c (HEAD -> main, upstream/main)
Author: Phil Karn <karn@ka9q.net>
Date:   Sun Jan 11 01:50:39 2026 -0800

    formatting